### PR TITLE
Perform additional null checks to prevent crash with some devices

### DIFF
--- a/src/main/java/wile/rsgauges/blocks/BlockAbstractGauge.java
+++ b/src/main/java/wile/rsgauges/blocks/BlockAbstractGauge.java
@@ -127,6 +127,10 @@ public abstract class BlockAbstractGauge extends RsDirectedBlock implements ModC
   public BlockState getStateForPlacement(BlockItemUseContext context)
   {
     final BlockState state = super.getStateForPlacement(context);
+    if(state==null)
+    {
+      return null;
+    }
     return (state.has(BlockGauge.POWER)) ? (state.with(BlockGauge.POWER, 0)) : (state);
   }
 

--- a/src/main/java/wile/rsgauges/blocks/BlockGauge.java
+++ b/src/main/java/wile/rsgauges/blocks/BlockGauge.java
@@ -56,7 +56,14 @@ public class BlockGauge extends BlockAbstractGauge implements ModColors.ColorTin
   @Override
   @Nullable
   public BlockState getStateForPlacement(BlockItemUseContext context)
-  { return super.getStateForPlacement(context).with(BlockGauge.POWER, 0); }
+  {
+    final BlockState state = super.getStateForPlacement(context);
+    if(state==null)
+    {
+      return null;
+    }
+    return state.with(BlockGauge.POWER, 0);
+  }
 
   // -------------------------------------------------------------------------------------------------------------------
   // Tile entity

--- a/src/main/java/wile/rsgauges/blocks/BlockIndicator.java
+++ b/src/main/java/wile/rsgauges/blocks/BlockIndicator.java
@@ -38,7 +38,14 @@ public class BlockIndicator extends BlockAbstractGauge
   @Override
   @Nullable
   public BlockState getStateForPlacement(BlockItemUseContext context)
-  { return super.getStateForPlacement(context).with(POWERED, context.getWorld().isBlockPowered(context.getPos())); }
+  {
+    final BlockState state = super.getStateForPlacement(context);
+    if(state==null)
+    {
+      return null;
+    }
+    return state.with(POWERED, context.getWorld().isBlockPowered(context.getPos()));
+  }
 
   // -------------------------------------------------------------------------------------------------------------------
   // Block overrides


### PR DESCRIPTION
The issue can be triggered by placing an indicator lamp or the offending blocks in this commit on a leaf block